### PR TITLE
Правит дату первого эпизода

### DIFF
--- a/src/episodes/1/index.md
+++ b/src/episodes/1/index.md
@@ -5,7 +5,7 @@ number: 1
 duration: 3018
 audio: episode-1.mp3
 audioSize: 60491700
-date: 2023-03-25
+date: 2023-04-25
 cover: cover.jpg
 tags: episode
 layout: episode.njk


### PR DESCRIPTION
Это не так страшно, но в моём плеере Pocket Casts первый эпизод не отображается в разделе New из-за этого.

Ну и фактическая дата выхода — это хорошо. Если я правильно понял замысел.