### PR TITLE
Правит селектор для добавления id к заголовкам

### DIFF
--- a/src/transforms/title-id-transform.js
+++ b/src/transforms/title-id-transform.js
@@ -5,13 +5,15 @@ const titleIdMap = JSON.parse(
 	fs.readFileSync(path.join(process.cwd(), 'title-id-map.json'), { encoding: 'utf-8' })
 );
 
+const contentContainerSelector = 'main.content > .post';
+
 /**
  * @param {ReturnType<import('linkedom').parseHTML>} window
  * @param {string} content
  * @param {string} outputPath
  */
 module.exports = function(window, content, outputPath) {
-	const contentElement = window.document.querySelector('.main .post');
+	const contentElement = window.document.querySelector(contentContainerSelector);
 
 	if (!contentElement) {
 		return;


### PR DESCRIPTION
После правок вёрстки не находится элемент, внутри которого нужно искать заголовки для добавления к ним id.